### PR TITLE
feat: show execution tests per commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ dist
 .DS_Store
 report.json
 ./.husky/_
-tdd_log.json
 .husky/.commit-state

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -5,5 +5,6 @@ node "$REPO_DIR/script/commit-tracker.js"
 
 export HUSKY=0
 git add script/commit-history.json
+git add script/tdd_log.json
 git commit --amend --no-edit 
 unset HUSKY

--- a/script/commit-history.json
+++ b/script/commit-history.json
@@ -1,0 +1,21 @@
+[
+  {
+    "sha": "HEAD",
+    "author": "Luzhania Cespedes Arancibia",
+    "commit": {
+      "date": "2025-10-18T15:22:36.000Z",
+      "message": "feat: show execution tests per commit",
+      "url": "https://github.com/luzhania/TDDLabBaseProject/commit/HEAD"
+    },
+    "stats": {
+      "total": 56,
+      "additions": 50,
+      "deletions": 6,
+      "date": "2025-10-18"
+    },
+    "coverage": 100,
+    "test_count": 1,
+    "failed_tests": 0,
+    "conclusion": "success"
+  }
+]

--- a/script/commitScript.js
+++ b/script/commitScript.js
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import path from 'path';
+import { getLastTestId } from './id_execution_tests_commit.js';
 
 const getLatestCommitId = () => {
     const latestCommit = execSync('git rev-parse HEAD').toString().trim();
@@ -18,8 +19,8 @@ const updateJsonFile = (commitId, commitName) => {
     const __dirname = path.dirname(__filename);
     const filePath = path.join(__dirname, 'tdd_log.json');
     const commitTimestamp = Date.now();
-    const data = { commitId, commitName, commitTimestamp };
-
+    let testId = getLastTestId(filePath);
+    const data = { commitId, commitName, commitTimestamp, testId };
     try {
         const fileData = fs.readFileSync(filePath, 'utf8');
         const existingData = JSON.parse(fileData);
@@ -36,4 +37,5 @@ const updateJsonFile = (commitId, commitName) => {
 
 const latestCommitId = getLatestCommitId();
 const latestCommitName = getLatestCommitName();
+
 updateJsonFile(latestCommitId, latestCommitName);

--- a/script/id_execution_tests_commit.js
+++ b/script/id_execution_tests_commit.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+
+const readJSONFile = (filePath) => {
+  const rawData = fs.readFileSync(filePath, 'utf-8');
+  return JSON.parse(rawData);
+};
+
+const writeJSONFile = (filePath, data) => {
+  const jsonString = JSON.stringify(data, null, 2);
+  fs.writeFileSync(filePath, jsonString, 'utf-8');
+};
+
+const ensureFileExists = (filePath, initialData) => {
+  if (!fs.existsSync(filePath)) {
+    writeJSONFile(filePath, initialData);
+  }
+};
+
+const isACommit = (lastEntry) => {
+  return lastEntry.hasOwnProperty('commitId');
+};
+
+const getLastTestId = (filePath) => {
+  ensureFileExists(filePath, []);
+  const historyExecutionData = readJSONFile(filePath);
+  const lastEntry = historyExecutionData[historyExecutionData.length - 1];
+  
+  if (lastEntry) {
+    if (isACommit(lastEntry)) {
+      return lastEntry.testId + 1; // Si el último es un commit, el próximo testId se incrementa
+    } else { //Ejecución de pruebas
+      return lastEntry.hasOwnProperty('testId') ? lastEntry.testId : 0; // Incrementa el testId
+    }
+  } else {
+    return 0; // Si el archivo está vacío, comienza con testId 0
+  }
+};
+
+export {getLastTestId };

--- a/script/tddScript.js
+++ b/script/tddScript.js
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'url';
 import fs from 'fs';
 import path from 'path';
 import { spawn } from 'cross-spawn';
+import { getLastTestId } from './id_execution_tests_commit.js';
 
 const COMMAND = 'jest';
 const args = ['--json', '--outputFile=./script/report.json'];
@@ -43,13 +44,15 @@ const extractAndAddObject = async (reportFile, tddLogFile) => {
     const totalTests = jsonData.numTotalTests;
     const startTime = jsonData.startTime;
     const success = jsonData.success;
+    let testId = getLastTestId(tddLogFile);
 
     const newReport = {
       numPassedTests: passedTests,
       failedTests: failedTests,
       numTotalTests: totalTests,
       timestamp: startTime,
-      success: success
+      success: success,
+      testId: testId
     };
 
     const tddLog = readJSONFile(tddLogFile);

--- a/script/tdd_log.json
+++ b/script/tdd_log.json
@@ -1,0 +1,8 @@
+[
+  {
+    "commitId": "85797877ab602d0972fb899a54e622b04098f4aa",
+    "commitName": "feat: show execution tests per commit",
+    "commitTimestamp": 1760800958042,
+    "testId": 0
+  }
+]


### PR DESCRIPTION
Cambio en el repositorio del proyecto base para que se muestren las gráficas de la ejecución de tests por commit.